### PR TITLE
Make installation instructions more explicit

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -15,6 +15,8 @@ Full example with at [laravel-5-4 branch](https://github.com/pionl/laravel-chunk
 composer install
 npm install
 npm run dev
+cp .env.example .env
+php artisan key:generate
 ```
 
 Optionally serve with `php artisan serve`


### PR DESCRIPTION
Creating the .env file might be obvious, but it is a necessary thing
to do, so it might be more convenient to state it explicitly.

Without it I got a 
```
Whoops, looks like something went wrong.
```
message.